### PR TITLE
Fix font on raspberry

### DIFF
--- a/hardware/src/web/css/main.css
+++ b/hardware/src/web/css/main.css
@@ -25,7 +25,7 @@ body {
     justify-content: center;
     background-color: gray;
     font-size: 17px;
-    font-weight: 500;
+    font-weight: 600;
 }
 
 .blue {

--- a/hardware/src/web/css/nfc.css
+++ b/hardware/src/web/css/nfc.css
@@ -11,7 +11,7 @@ body {
 
 #textWriter {
     font-size: 17px;
-    font-weight: 500;
+    font-weight: 600;
     color: white;
 }
 

--- a/hardware/src/web/css/scan.css
+++ b/hardware/src/web/css/scan.css
@@ -13,7 +13,7 @@
 
 p {
     font-size: 17px;
-    font-weight: 500;
+    font-weight: 600;
     color: white;
     margin-top: 0;
 }


### PR DESCRIPTION
La taille de la police rend pas pareil sur la raspi que sur navigateur ordi
Du coup les textes dépassaient des boutons de manière chelou